### PR TITLE
Replacing refined with iron

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,6 @@ lazy val root = (project in file(".")).settings(
 
     // for data semantics
     "io.github.iltotore" %% "iron" % ironV,
-    "eu.timepit" %% "refined" % "0.11.3",
 
     // for better enumeration
     "com.beachape" %% "enumeratum" % "1.9.0",

--- a/src/main/scala/org/scalabridge/sitegen/StaticSiteGenerator.scala
+++ b/src/main/scala/org/scalabridge/sitegen/StaticSiteGenerator.scala
@@ -1,30 +1,30 @@
 package org.scalabridge.sitegen
 
 import cats.syntax.all._
-import eu.timepit.refined.types.string.NonEmptyString
 import org.scalabridge._
-import org.scalabridge.sitegen.domain.model._
+import io.github.iltotore.iron.*
 import parsley.Parsley.many
 import parsley._
 import parsley.character._
 import parsley.combinator.manyTill
+import org.scalabridge.sitegen.domain.model.*
 
 object StaticSiteGenerator {
   private val ws: Parsley[Unit] = Parsley.many(space).void
 
   val h1Parser: Parsley[H1] = for {
     in <- char('#') ~> ws ~> many(satisfy(_ != '\n')) <~ newline
-    value <- NonEmptyString.from(in.mkString) match {
-      case Right(v) => Parsley.pure(v)
-      case _        => Parsley.empty
+    value <- in.mkString.refineEither[NonEmptyString] match {
+      case Left(value) => Parsley.empty
+      case Right(value) => Parsley.pure(value)
     }
   } yield H1(value)
 
   val underLinedParser: Parsley[Underlined] = for {
     in <- string("__") ~> manyTill(item, string("__")) <~ newline
-    value <- NonEmptyString.from(in.mkString) match {
-      case Right(v) => Parsley.pure(v)
-      case _        => Parsley.empty
+    value <- in.mkString.refineEither[NonEmptyString] match {
+      case Left(value) => Parsley.empty
+      case Right(value) => Parsley.pure(value)
     }
   } yield Underlined(value)
 

--- a/src/main/scala/org/scalabridge/sitegen/StaticSiteGenerator.scala
+++ b/src/main/scala/org/scalabridge/sitegen/StaticSiteGenerator.scala
@@ -15,7 +15,7 @@ object StaticSiteGenerator {
   val h1Parser: Parsley[H1] = for {
     in <- char('#') ~> ws ~> many(satisfy(_ != '\n')) <~ newline
     value <- in.mkString.refineEither[NonEmptyString] match {
-      case Left(value) => Parsley.empty
+      case Left(value)  => Parsley.empty
       case Right(value) => Parsley.pure(value)
     }
   } yield H1(value)
@@ -23,7 +23,7 @@ object StaticSiteGenerator {
   val underLinedParser: Parsley[Underlined] = for {
     in <- string("__") ~> manyTill(item, string("__")) <~ newline
     value <- in.mkString.refineEither[NonEmptyString] match {
-      case Left(value) => Parsley.empty
+      case Left(value)  => Parsley.empty
       case Right(value) => Parsley.pure(value)
     }
   } yield Underlined(value)

--- a/src/main/scala/org/scalabridge/sitegen/domain/model.scala
+++ b/src/main/scala/org/scalabridge/sitegen/domain/model.scala
@@ -1,24 +1,27 @@
 package org.scalabridge.sitegen.domain
 
-import eu.timepit.refined.types.all.NonEmptyString
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.all.MinLength
 
 object model {
 
+  type NonEmptyString = DescribedAs[MinLength[1], "String should not be empty"]
+
   // AST definitions
   sealed trait AST
-  final case class H1(value: NonEmptyString) extends AST
-  final case class H2(value: NonEmptyString) extends AST
-  final case class H3(value: NonEmptyString) extends AST
-  final case class Bold(value: NonEmptyString) extends AST
-  final case class Italic(value: NonEmptyString) extends AST
-  final case class Link(value: NonEmptyString) extends AST
-  final case class Underlined(value: NonEmptyString) extends AST
-  final case class Paragraph(value: NonEmptyString) extends AST
-  final case class UnorderedListItem(value: NonEmptyString) extends AST
-  final case class OrderedListItem(value: NonEmptyString) extends AST
+  final case class H1(value: String :| NonEmptyString) extends AST
+  final case class H2(value: String :| NonEmptyString) extends AST
+  final case class H3(value: String :| NonEmptyString) extends AST
+  final case class Bold(value: String :| NonEmptyString) extends AST
+  final case class Italic(value: String :| NonEmptyString) extends AST
+  final case class Link(value: String :| NonEmptyString) extends AST
+  final case class Underlined(value: String :| NonEmptyString) extends AST
+  final case class Paragraph(value: String :| NonEmptyString) extends AST
+  final case class UnorderedListItem(value: String :| NonEmptyString) extends AST
+  final case class OrderedListItem(value: String :| NonEmptyString) extends AST
 
   // naive weak and brittle smart constructor
-  def mkNode(value: NonEmptyString, typ: String): AST = typ match {
+  def mkNode(value: String :| NonEmptyString, typ: String): AST = typ match {
     case "h1"     => H1(value)
     case "h2"     => H2(value)
     case "h3"     => H3(value)
@@ -35,39 +38,39 @@ object model {
   sealed trait HTML {
     def render: String
   }
-  final case class H1Html(value: NonEmptyString) extends HTML {
+  final case class H1Html(value: String :| NonEmptyString) extends HTML {
     override def render: String = s"<h1>$value</h1>"
   }
-  final case class H2Html(value: NonEmptyString) extends HTML {
+  final case class H2Html(value: String :| NonEmptyString) extends HTML {
     override def render: String = s"<h2>$value</h1>"
   }
-  final case class H3Html(value: NonEmptyString) extends HTML {
+  final case class H3Html(value: String :| NonEmptyString) extends HTML {
     override def render: String = s"<h3>$value</h1>"
   }
-  final case class BoldHtml(value: NonEmptyString) extends HTML {
+  final case class BoldHtml(value: String :| NonEmptyString) extends HTML {
     override def render: String = s"<strong>$value</strong>"
   }
-  final case class ItalicHtml(value: NonEmptyString) extends HTML {
+  final case class ItalicHtml(value: String :| NonEmptyString) extends HTML {
     override def render: String = s"<em>$value</em>"
   }
-  final case class LinkHtml(value: NonEmptyString) extends HTML {
+  final case class LinkHtml(value: String :| NonEmptyString) extends HTML {
     override def render: String = s"<a href=$value>$value</h1>"
   }
-  final case class UnderlinedHtml(value: NonEmptyString) extends HTML {
+  final case class UnderlinedHtml(value: String :| NonEmptyString) extends HTML {
     override def render: String = s"<u>$value</u>"
   }
-  final case class ParagraphHtml(value: NonEmptyString) extends HTML {
+  final case class ParagraphHtml(value: String :| NonEmptyString) extends HTML {
     override def render: String = s"<p>$value</p>"
   }
-  final case class UnorderedListItemHtml(value: NonEmptyString) extends HTML {
+  final case class UnorderedListItemHtml(value: String :| NonEmptyString) extends HTML {
     override def render: String = s"<ul><li>$value</li></ul>"
   }
-  final case class OrderedListItemHtml(value: NonEmptyString) extends HTML {
+  final case class OrderedListItemHtml(value: String :| NonEmptyString) extends HTML {
     override def render: String = s"<ol><li>$value</li></ol>"
   }
 
   // naive, weak and brittle smart constructor
-  def mkHtml(value: NonEmptyString, typ: String): HTML = typ match {
+  def mkHtml(value: String :| NonEmptyString, typ: String): HTML = typ match {
     case "h1"     => H1Html(value)
     case "h2"     => H2Html(value)
     case "h3"     => H3Html(value)

--- a/src/test/scala/org/scalabridge/sitegen/StaticSiteGeneratorSuite.scala
+++ b/src/test/scala/org/scalabridge/sitegen/StaticSiteGeneratorSuite.scala
@@ -1,7 +1,7 @@
 package org.scalabridge.sitegen
 
-import munit.ScalaCheckSuite
 import org.scalabridge.sitegen.StaticSiteGenerator.{generateHtml, h1Parser, parse, underLinedParser}
+import munit.ScalaCheckSuite
 import org.scalabridge.sitegen.generators.misc.nonEmptyStringGen
 import org.scalacheck.Prop.forAll
 

--- a/src/test/scala/org/scalabridge/sitegen/generators/misc.scala
+++ b/src/test/scala/org/scalabridge/sitegen/generators/misc.scala
@@ -1,9 +1,10 @@
 package org.scalabridge.sitegen.generators
 
-import eu.timepit.refined.types.string.NonEmptyString
 import org.scalacheck.Gen
+import org.scalabridge.sitegen.domain.model.NonEmptyString
+import io.github.iltotore.iron.*
 
 object misc {
-  val nonEmptyStringGen: Gen[NonEmptyString] =
-    Gen.nonEmptyStringOf(Gen.alphaNumChar).map(NonEmptyString.unsafeFrom)
+  val nonEmptyStringGen: Gen[String :| NonEmptyString] =
+    Gen.nonEmptyStringOf(Gen.alphaNumChar).map(_.refineUnsafe)
 }


### PR DESCRIPTION
After upgrading to Scala 3, it was suggested that we use Iron instead of refined types. 

If anyone has a more idiomatic way of referring to the type as `NonEmptyString` rather than `String :| NonEmptyString`, I'd like to hear it. 