### PR TITLE
Configure Scalafmt for Scala 3

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,6 +1,6 @@
 version = "3.5.8"
 
-runner.dialect = scala213
+runner.dialect = scala3
 
 # Line length
 maxColumn = 100


### PR DESCRIPTION
I'm not sure if you want to specifically use Scala 2.13 syntax, though this sets the formatter dialect to Scala 3.